### PR TITLE
feat(web): stabilize dashboard shell UX baseline

### DIFF
--- a/apps/web/src/app/[...slug]/page.tsx
+++ b/apps/web/src/app/[...slug]/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import { Button, Card, CardContent } from '@goran/ui-components';
+
+type RoutePlaceholderPageProps = {
+    params: Promise<{ slug: string[] }>;
+};
+
+export default async function RoutePlaceholderPage({
+    params,
+}: RoutePlaceholderPageProps) {
+    const { slug } = await params;
+    const path = `/${slug.join('/')}`;
+
+    return (
+        <main className="flex min-h-svh items-center justify-center bg-background px-6 py-12 text-foreground">
+            <Card className="w-full max-w-lg border-border">
+                <CardContent className="space-y-4 p-6">
+                    <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+                        Coming Soon
+                    </p>
+                    <h1 className="text-2xl font-semibold">
+                        This section is not ready yet
+                    </h1>
+                    <p className="text-sm text-muted-foreground">
+                        The page{' '}
+                        <code className="rounded bg-muted px-1 py-0.5">
+                            {path}
+                        </code>{' '}
+                        is part of the dashboard shell and will be connected in
+                        the next feature pass.
+                    </p>
+                    <Button asChild>
+                        <Link href="/">Back to dashboard</Link>
+                    </Button>
+                </CardContent>
+            </Card>
+        </main>
+    );
+}

--- a/apps/web/src/app/_components/app-sidebar.tsx
+++ b/apps/web/src/app/_components/app-sidebar.tsx
@@ -40,54 +40,26 @@ import {
 } from 'lucide-react';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 
 function AnimatedSidebarLink({
     href,
     children,
+    isActive = false,
 }: {
     href: string;
     children: React.ReactNode;
+    isActive?: boolean;
 }) {
     return (
         <SidebarMenuButton
             asChild
-            className="relative overflow-hidden hover:bg-muted transition-colors"
+            isActive={isActive}
+            className="justify-start transition-colors"
         >
-            <Link
-                href={href}
-                className="flex items-center gap-2 min-w-0 relative z-10"
-            >
+            <Link href={href} className="flex min-w-0 items-center gap-2">
                 {children}
-                <motion.div
-                    className="absolute inset-0 z-0"
-                    initial={{
-                        opacity: 0,
-                        backgroundPositionX: '100%',
-                        boxShadow: '0 0 0px hsl(var(--primary) / 0)',
-                    }}
-                    whileHover={{
-                        opacity: 1,
-                        backgroundPositionX: '-100%',
-                        boxShadow: '0 0 20px hsl(var(--primary) / 0.8)',
-                        transition: {
-                            backgroundPositionX: {
-                                duration: 1.5,
-                                ease: 'linear',
-                                repeat: Number.POSITIVE_INFINITY,
-                                repeatType: 'loop',
-                            },
-                            opacity: { duration: 0.4 },
-                            boxShadow: { duration: 0.4 },
-                        },
-                    }}
-                    style={{
-                        background:
-                            'linear-gradient(90deg, hsl(var(--primary) / 0) 0%, hsl(var(--primary) / 0.9) 15%, hsl(var(--primary) / 0.9) 85%, hsl(var(--primary) / 0) 100%)',
-                        backgroundSize: '300% 100%',
-                        pointerEvents: 'none',
-                    }}
-                />
             </Link>
         </SidebarMenuButton>
     );
@@ -121,10 +93,12 @@ const initialPlaylists = [
 ];
 
 export default function AppSidebar() {
+    const pathname = usePathname();
     const [createPlaylistDialogOpen, setCreatePlaylistDialogOpen] =
         useState(false);
     const [newPlaylistName, setNewPlaylistName] = useState('New Playlist');
     const [playlists, setPlaylists] = useState(initialPlaylists);
+    const [lastCreatedPlaylistName, setLastCreatedPlaylistName] = useState('');
 
     const handleCreatePlaylist = () => {
         const name =
@@ -133,9 +107,13 @@ export default function AppSidebar() {
             { id: `p${Date.now()}`, name, tracks: 0 },
             ...current,
         ]);
+        setLastCreatedPlaylistName(name);
         setCreatePlaylistDialogOpen(false);
         setNewPlaylistName('New Playlist');
     };
+
+    const isActivePath = (href: string) =>
+        href === '/' ? pathname === '/' : pathname.startsWith(href);
 
     return (
         <Sidebar
@@ -163,7 +141,10 @@ export default function AppSidebar() {
                         <SidebarMenu>
                             {primaryLinks.map((item) => (
                                 <SidebarMenuItem key={item.href}>
-                                    <AnimatedSidebarLink href={item.href}>
+                                    <AnimatedSidebarLink
+                                        href={item.href}
+                                        isActive={isActivePath(item.href)}
+                                    >
                                         <item.icon />
                                         <span>{item.label}</span>
                                     </AnimatedSidebarLink>
@@ -183,7 +164,10 @@ export default function AppSidebar() {
                         <SidebarMenu>
                             {libraryLinks.map((item) => (
                                 <SidebarMenuItem key={item.href}>
-                                    <AnimatedSidebarLink href={item.href}>
+                                    <AnimatedSidebarLink
+                                        href={item.href}
+                                        isActive={isActivePath(item.href)}
+                                    >
                                         <item.icon />
                                         <span>{item.label}</span>
                                     </AnimatedSidebarLink>
@@ -249,10 +233,26 @@ export default function AppSidebar() {
                                                     e.target.value,
                                                 )
                                             }
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter') {
+                                                    e.preventDefault();
+                                                    handleCreatePlaylist();
+                                                }
+                                            }}
                                             placeholder="Playlist name"
                                             className="bg-input border-border"
                                         />
                                         <DialogFooter>
+                                            <Button
+                                                variant="outline"
+                                                onClick={() =>
+                                                    setCreatePlaylistDialogOpen(
+                                                        false,
+                                                    )
+                                                }
+                                            >
+                                                Cancel
+                                            </Button>
                                             <Button
                                                 onClick={handleCreatePlaylist}
                                                 className="bg-primary text-primary-foreground hover:bg-primary/90"
@@ -268,6 +268,10 @@ export default function AppSidebar() {
                                 <SidebarMenuItem key={playlist.id}>
                                     <AnimatedSidebarLink
                                         href={`/playlists/${playlist.id}`}
+                                        isActive={
+                                            pathname ===
+                                            `/playlists/${playlist.id}`
+                                        }
                                     >
                                         <ListMusic />
                                         <div className="min-w-0">
@@ -282,6 +286,14 @@ export default function AppSidebar() {
                                 </SidebarMenuItem>
                             ))}
                         </SidebarMenu>
+                        <p
+                            aria-live="polite"
+                            className="px-2 pt-2 text-xs text-muted-foreground"
+                        >
+                            {lastCreatedPlaylistName
+                                ? `Created: ${lastCreatedPlaylistName}`
+                                : 'Create playlists to organize your listening.'}
+                        </p>
                     </SidebarGroupContent>
                 </SidebarGroup>
             </SidebarContent>

--- a/apps/web/src/app/_components/music-app.tsx
+++ b/apps/web/src/app/_components/music-app.tsx
@@ -102,6 +102,20 @@ const releases = [
     { id: 'r3', name: 'Sea Glass', artist: 'Waveside', trackId: 't2' },
 ];
 
+function getRandomIndex(length: number) {
+    if (length <= 0) {
+        return 0;
+    }
+
+    if (typeof globalThis.crypto !== 'undefined') {
+        const randomBuffer = new Uint32Array(1);
+        globalThis.crypto.getRandomValues(randomBuffer);
+        return randomBuffer[0] % length;
+    }
+
+    return 0;
+}
+
 function formatDuration(totalSeconds: number) {
     const minutes = Math.floor(totalSeconds / 60);
     const seconds = totalSeconds % 60;
@@ -224,7 +238,7 @@ export default function MusicApp() {
         if (!trendingTracks.length) {
             return;
         }
-        const randomIndex = Math.floor(Math.random() * trendingTracks.length);
+        const randomIndex = getRandomIndex(trendingTracks.length);
         setCurrentTrackIndex(randomIndex);
         setElapsedSec(0);
         setIsPlaying(true);

--- a/apps/web/src/app/_components/music-app.tsx
+++ b/apps/web/src/app/_components/music-app.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import {
     Avatar,
@@ -14,9 +14,11 @@ import {
     SidebarInset,
     SidebarProvider,
     SidebarTrigger,
+    Skeleton,
 } from '@goran/ui-components';
 import {
     Headphones,
+    Pause,
     Play,
     Search,
     Shuffle,
@@ -24,68 +26,217 @@ import {
     SkipForward,
     Upload,
     Volume2,
+    VolumeX,
+    X,
 } from 'lucide-react';
 import AppSidebar from './app-sidebar';
 
+type Track = {
+    id: string;
+    title: string;
+    artist: string;
+    album: string;
+    durationSec: number;
+};
+
+const SIDEBAR_STORAGE_KEY = 'dashboard.sidebar.open';
+
 const quickMixes = [
     {
+        id: 'mix1',
         title: 'Midnight Focus',
         subtitle: 'Synthwave and lo-fi',
         accent: 'from-cyan-500/30 to-blue-500/10',
+        startingTrackId: 't1',
     },
     {
+        id: 'mix2',
         title: 'Sunday Vinyl',
         subtitle: 'Soul, jazz and classics',
         accent: 'from-amber-500/30 to-orange-500/10',
+        startingTrackId: 't2',
     },
     {
+        id: 'mix3',
         title: 'Deep Work',
         subtitle: 'Ambient, instrumental',
         accent: 'from-emerald-500/30 to-teal-500/10',
+        startingTrackId: 't3',
     },
 ];
 
-const trendingTracks = [
+const trendingTracks: Track[] = [
     {
         id: 't1',
         title: 'Atlas',
         artist: 'Nova Hall',
         album: 'Echoes',
-        duration: '3:41',
+        durationSec: 221,
     },
     {
         id: 't2',
         title: 'Blue Hour',
         artist: 'Waveside',
         album: 'Sea Glass',
-        duration: '4:02',
+        durationSec: 242,
     },
     {
         id: 't3',
         title: 'Pixel Heart',
         artist: 'Kairo',
         album: 'Afterglow',
-        duration: '2:58',
+        durationSec: 178,
     },
     {
         id: 't4',
         title: 'Starlit',
         artist: 'Mira Stone',
         album: 'Skyline',
-        duration: '3:19',
+        durationSec: 199,
     },
 ];
 
 const releases = [
-    { id: 'r1', name: 'Skyline', artist: 'Mira Stone' },
-    { id: 'r2', name: 'Afterglow', artist: 'Kairo' },
-    { id: 'r3', name: 'Sea Glass', artist: 'Waveside' },
+    { id: 'r1', name: 'Skyline', artist: 'Mira Stone', trackId: 't4' },
+    { id: 'r2', name: 'Afterglow', artist: 'Kairo', trackId: 't3' },
+    { id: 'r3', name: 'Sea Glass', artist: 'Waveside', trackId: 't2' },
 ];
 
+function formatDuration(totalSeconds: number) {
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
 export default function MusicApp() {
+    const [sidebarOpen, setSidebarOpen] = useState(true);
+    const [isLoading, setIsLoading] = useState(true);
+    const [query, setQuery] = useState('');
+    const [isPlaying, setIsPlaying] = useState(false);
+    const [currentTrackIndex, setCurrentTrackIndex] = useState(0);
+    const [elapsedSec, setElapsedSec] = useState(0);
+    const [isMuted, setIsMuted] = useState(false);
+    const searchInputRef = useRef<HTMLInputElement | null>(null);
+
+    const filteredTracks = useMemo(() => {
+        if (!query.trim()) {
+            return trendingTracks;
+        }
+
+        const needle = query.trim().toLowerCase();
+        return trendingTracks.filter(
+            (track) =>
+                track.title.toLowerCase().includes(needle) ||
+                track.artist.toLowerCase().includes(needle) ||
+                track.album.toLowerCase().includes(needle),
+        );
+    }, [query]);
+
+    const currentTrack =
+        trendingTracks[currentTrackIndex] ?? trendingTracks[0] ?? null;
+
+    useEffect(() => {
+        const saved = window.localStorage.getItem(SIDEBAR_STORAGE_KEY);
+        if (saved === 'true' || saved === 'false') {
+            setSidebarOpen(saved === 'true');
+        }
+        const timer = window.setTimeout(() => {
+            setIsLoading(false);
+        }, 320);
+        return () => window.clearTimeout(timer);
+    }, []);
+
+    useEffect(() => {
+        window.localStorage.setItem(SIDEBAR_STORAGE_KEY, String(sidebarOpen));
+    }, [sidebarOpen]);
+
+    useEffect(() => {
+        if (!isPlaying || !currentTrack) {
+            return;
+        }
+
+        const timer = window.setInterval(() => {
+            setElapsedSec((current) => {
+                if (current >= currentTrack.durationSec) {
+                    setCurrentTrackIndex(
+                        (index) => (index + 1) % trendingTracks.length,
+                    );
+                    return 0;
+                }
+                return current + 1;
+            });
+        }, 1000);
+
+        return () => window.clearInterval(timer);
+    }, [isPlaying, currentTrack]);
+
+    useEffect(() => {
+        const handler = (event: KeyboardEvent) => {
+            if (event.key === '/' && !(event.metaKey || event.ctrlKey)) {
+                const target = event.target as HTMLElement | null;
+                const isTypingContext =
+                    target?.tagName === 'INPUT' ||
+                    target?.tagName === 'TEXTAREA' ||
+                    target?.isContentEditable;
+                if (!isTypingContext) {
+                    event.preventDefault();
+                    searchInputRef.current?.focus();
+                }
+            }
+
+            if (event.key === 'Escape') {
+                setQuery('');
+            }
+        };
+
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, []);
+
+    const playTrackById = (trackId: string) => {
+        const index = trendingTracks.findIndex((track) => track.id === trackId);
+        if (index >= 0) {
+            setCurrentTrackIndex(index);
+            setElapsedSec(0);
+            setIsPlaying(true);
+        }
+    };
+
+    const playTrackByIndex = (index: number) => {
+        setCurrentTrackIndex(index);
+        setElapsedSec(0);
+        setIsPlaying(true);
+    };
+
+    const goToPreviousTrack = () => {
+        setCurrentTrackIndex((index) =>
+            index <= 0 ? trendingTracks.length - 1 : index - 1,
+        );
+        setElapsedSec(0);
+    };
+
+    const goToNextTrack = () => {
+        setCurrentTrackIndex((index) => (index + 1) % trendingTracks.length);
+        setElapsedSec(0);
+    };
+
+    const shuffleTrack = () => {
+        if (!trendingTracks.length) {
+            return;
+        }
+        const randomIndex = Math.floor(Math.random() * trendingTracks.length);
+        setCurrentTrackIndex(randomIndex);
+        setElapsedSec(0);
+        setIsPlaying(true);
+    };
+
+    const progressValue = currentTrack
+        ? Math.round((elapsedSec / currentTrack.durationSec) * 100)
+        : 0;
+
     return (
-        <div className="min-h-svh bg-background text-foreground relative overflow-hidden">
-            <SidebarProvider defaultOpen>
+        <div className="relative min-h-svh overflow-hidden bg-background text-foreground">
+            <SidebarProvider open={sidebarOpen} onOpenChange={setSidebarOpen}>
                 <AppSidebar />
                 <SidebarInset className="relative">
                     <motion.header
@@ -97,22 +248,46 @@ export default function MusicApp() {
                             damping: 16,
                             mass: 0.7,
                         }}
-                        className="sticky top-0 z-20 flex items-center gap-4 px-6 py-4 backdrop-blur supports-[backdrop-filter]:bg-background/80 bg-background/90 border-b border-border"
+                        className="sticky top-0 z-20 flex items-center gap-3 border-b border-border bg-background/90 px-4 py-4 backdrop-blur supports-[backdrop-filter]:bg-background/80 md:px-6"
                     >
-                        <SidebarTrigger className="text-muted-foreground hover:text-foreground transition-colors" />
+                        <SidebarTrigger
+                            aria-label="Toggle sidebar"
+                            className="text-muted-foreground transition-colors hover:text-foreground"
+                        />
                         <div className="relative flex-1 max-w-2xl">
                             <Search className="pointer-events-none absolute left-3 top-2.5 size-4 text-muted-foreground" />
                             <Input
-                                className="pl-9"
+                                ref={searchInputRef}
+                                className="pl-9 pr-9"
+                                value={query}
+                                onChange={(event) =>
+                                    setQuery(event.currentTarget.value)
+                                }
                                 placeholder="Search tracks, artists, albums..."
+                                aria-label="Search tracks"
                             />
+                            {query ? (
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="absolute right-1 top-1 h-7 w-7"
+                                    aria-label="Clear search"
+                                    onClick={() => setQuery('')}
+                                >
+                                    <X className="size-4" />
+                                </Button>
+                            ) : null}
                         </div>
                         <div className="hidden md:flex items-center gap-2">
                             <Button size="sm" variant="secondary">
                                 <Upload className="size-4" />
                                 Upload
                             </Button>
-                            <Button size="sm" variant="outline">
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={shuffleTrack}
+                            >
                                 <Shuffle className="size-4" />
                                 Shuffle
                             </Button>
@@ -122,7 +297,7 @@ export default function MusicApp() {
                         </Avatar>
                     </motion.header>
 
-                    <div className="p-6 pb-28">
+                    <div className="p-4 pb-28 md:p-6 md:pb-28">
                         <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
                             <div className="space-y-6">
                                 <motion.section
@@ -142,10 +317,10 @@ export default function MusicApp() {
                                     <div className="grid gap-4 md:grid-cols-3">
                                         {quickMixes.map((mix) => (
                                             <Card
-                                                key={mix.title}
+                                                key={mix.id}
                                                 className={`overflow-hidden border-border bg-gradient-to-br ${mix.accent}`}
                                             >
-                                                <CardContent className="p-4 space-y-3">
+                                                <CardContent className="space-y-3 p-4">
                                                     <Badge
                                                         variant="secondary"
                                                         className="w-fit"
@@ -163,6 +338,11 @@ export default function MusicApp() {
                                                     <Button
                                                         size="sm"
                                                         className="w-full"
+                                                        onClick={() =>
+                                                            playTrackById(
+                                                                mix.startingTrackId,
+                                                            )
+                                                        }
                                                     >
                                                         <Play className="size-4" />
                                                         Play now
@@ -187,36 +367,82 @@ export default function MusicApp() {
                                             View chart
                                         </Button>
                                     </div>
-                                    <Card>
-                                        <CardContent className="p-0">
-                                            {trendingTracks.map(
-                                                (track, index) => (
-                                                    <div
-                                                        key={track.id}
-                                                        className="grid grid-cols-[32px_minmax(0,1fr)_minmax(0,1fr)_56px] items-center gap-4 px-4 py-3 border-b last:border-b-0 border-border"
-                                                    >
-                                                        <span className="text-sm text-muted-foreground">
-                                                            {index + 1}
-                                                        </span>
-                                                        <div className="min-w-0">
-                                                            <p className="truncate font-medium">
-                                                                {track.title}
-                                                            </p>
-                                                            <p className="truncate text-xs text-muted-foreground">
-                                                                {track.artist}
-                                                            </p>
-                                                        </div>
-                                                        <p className="truncate text-sm text-muted-foreground">
-                                                            {track.album}
-                                                        </p>
-                                                        <p className="text-sm text-muted-foreground text-right">
-                                                            {track.duration}
-                                                        </p>
-                                                    </div>
-                                                ),
-                                            )}
-                                        </CardContent>
-                                    </Card>
+
+                                    {isLoading ? (
+                                        <Card>
+                                            <CardContent className="space-y-3 p-4">
+                                                <Skeleton className="h-10 w-full" />
+                                                <Skeleton className="h-10 w-full" />
+                                                <Skeleton className="h-10 w-full" />
+                                            </CardContent>
+                                        </Card>
+                                    ) : filteredTracks.length ? (
+                                        <Card>
+                                            <CardContent className="p-0">
+                                                {filteredTracks.map(
+                                                    (track, index) => {
+                                                        const absoluteIndex =
+                                                            trendingTracks.findIndex(
+                                                                (candidate) =>
+                                                                    candidate.id ===
+                                                                    track.id,
+                                                            );
+                                                        const isCurrent =
+                                                            currentTrack?.id ===
+                                                            track.id;
+                                                        return (
+                                                            <button
+                                                                type="button"
+                                                                key={track.id}
+                                                                onClick={() =>
+                                                                    playTrackByIndex(
+                                                                        absoluteIndex,
+                                                                    )
+                                                                }
+                                                                className="grid w-full grid-cols-[32px_minmax(0,1fr)_minmax(0,1fr)_56px] items-center gap-4 border-b border-border px-4 py-3 text-left transition-colors hover:bg-muted/40 last:border-b-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                                                            >
+                                                                <span className="text-sm text-muted-foreground">
+                                                                    {index + 1}
+                                                                </span>
+                                                                <div className="min-w-0">
+                                                                    <p
+                                                                        className={`truncate font-medium ${isCurrent ? 'text-primary' : ''}`}
+                                                                    >
+                                                                        {
+                                                                            track.title
+                                                                        }
+                                                                    </p>
+                                                                    <p className="truncate text-xs text-muted-foreground">
+                                                                        {
+                                                                            track.artist
+                                                                        }
+                                                                    </p>
+                                                                </div>
+                                                                <p className="truncate text-sm text-muted-foreground">
+                                                                    {
+                                                                        track.album
+                                                                    }
+                                                                </p>
+                                                                <p className="text-right text-sm text-muted-foreground">
+                                                                    {formatDuration(
+                                                                        track.durationSec,
+                                                                    )}
+                                                                </p>
+                                                            </button>
+                                                        );
+                                                    },
+                                                )}
+                                            </CardContent>
+                                        </Card>
+                                    ) : (
+                                        <Card>
+                                            <CardContent className="p-6 text-sm text-muted-foreground">
+                                                No tracks found for &quot;
+                                                {query}&quot;. Try another
+                                                keyword.
+                                            </CardContent>
+                                        </Card>
+                                    )}
                                 </motion.section>
                             </div>
 
@@ -227,32 +453,41 @@ export default function MusicApp() {
                                 className="space-y-4"
                             >
                                 <Card>
-                                    <CardContent className="p-4 space-y-4">
+                                    <CardContent className="space-y-4 p-4">
                                         <div className="flex items-center justify-between">
                                             <h3 className="font-semibold">
                                                 Now playing
                                             </h3>
                                             <Headphones className="size-4 text-muted-foreground" />
                                         </div>
-                                        <div className="aspect-square rounded-lg bg-gradient-to-br from-indigo-500/40 to-cyan-500/20 border border-border" />
+                                        <div className="aspect-square rounded-lg border border-border bg-gradient-to-br from-indigo-500/40 to-cyan-500/20" />
                                         <div>
                                             <p className="font-medium">
-                                                Neon Circuit
+                                                {currentTrack?.title ??
+                                                    'No track selected'}
                                             </p>
                                             <p className="text-sm text-muted-foreground">
-                                                Mira Stone
+                                                {currentTrack?.artist ??
+                                                    'Pick a track to start'}
                                             </p>
                                         </div>
-                                        <Progress value={38} />
+                                        <Progress value={progressValue} />
                                         <div className="flex items-center justify-between text-sm text-muted-foreground">
-                                            <span>1:22</span>
-                                            <span>3:41</span>
+                                            <span>
+                                                {formatDuration(elapsedSec)}
+                                            </span>
+                                            <span>
+                                                {formatDuration(
+                                                    currentTrack?.durationSec ??
+                                                        0,
+                                                )}
+                                            </span>
                                         </div>
                                     </CardContent>
                                 </Card>
 
                                 <Card>
-                                    <CardContent className="p-4 space-y-3">
+                                    <CardContent className="space-y-3 p-4">
                                         <h3 className="font-semibold">
                                             New releases
                                         </h3>
@@ -273,6 +508,12 @@ export default function MusicApp() {
                                                     variant="ghost"
                                                     size="icon"
                                                     className="shrink-0"
+                                                    aria-label={`Play ${release.name}`}
+                                                    onClick={() =>
+                                                        playTrackById(
+                                                            release.trackId,
+                                                        )
+                                                    }
                                                 >
                                                     <Play className="size-4" />
                                                 </Button>
@@ -284,25 +525,50 @@ export default function MusicApp() {
                         </div>
                     </div>
 
-                    <div className="sticky bottom-0 bg-background/95 backdrop-blur border-t border-border px-4 py-3">
+                    <div className="sticky bottom-0 border-t border-border bg-background/95 px-4 py-3 backdrop-blur">
                         <div className="flex items-center gap-4">
-                            <div className="hidden sm:block size-11 rounded-md bg-gradient-to-br from-indigo-500/40 to-cyan-500/20 border border-border" />
+                            <div className="hidden size-11 rounded-md border border-border bg-gradient-to-br from-indigo-500/40 to-cyan-500/20 sm:block" />
                             <div className="min-w-0 flex-1">
                                 <p className="truncate text-sm font-medium">
-                                    Neon Circuit
+                                    {currentTrack?.title ?? 'No track selected'}
                                 </p>
                                 <p className="truncate text-xs text-muted-foreground">
-                                    Mira Stone
+                                    {currentTrack?.artist ??
+                                        'Choose a track to begin'}
                                 </p>
                             </div>
                             <div className="flex items-center gap-2">
-                                <Button variant="ghost" size="icon">
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    aria-label="Previous track"
+                                    onClick={goToPreviousTrack}
+                                >
                                     <SkipBack className="size-4" />
                                 </Button>
-                                <Button size="icon">
-                                    <Play className="size-4" />
+                                <Button
+                                    size="icon"
+                                    aria-label={
+                                        isPlaying
+                                            ? 'Pause playback'
+                                            : 'Play track'
+                                    }
+                                    onClick={() =>
+                                        setIsPlaying((value) => !value)
+                                    }
+                                >
+                                    {isPlaying ? (
+                                        <Pause className="size-4" />
+                                    ) : (
+                                        <Play className="size-4" />
+                                    )}
                                 </Button>
-                                <Button variant="ghost" size="icon">
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    aria-label="Next track"
+                                    onClick={goToNextTrack}
+                                >
                                     <SkipForward className="size-4" />
                                 </Button>
                             </div>
@@ -310,8 +576,14 @@ export default function MusicApp() {
                                 variant="ghost"
                                 size="icon"
                                 className="hidden md:inline-flex"
+                                aria-label={isMuted ? 'Unmute' : 'Mute'}
+                                onClick={() => setIsMuted((value) => !value)}
                             >
-                                <Volume2 className="size-4" />
+                                {isMuted ? (
+                                    <VolumeX className="size-4" />
+                                ) : (
+                                    <Volume2 className="size-4" />
+                                )}
                             </Button>
                         </div>
                     </div>

--- a/apps/web/src/app/global.css
+++ b/apps/web/src/app/global.css
@@ -1,4 +1,7 @@
 @import 'tailwindcss';
+@config '../../tailwind.config.ts';
+@source '../../src/**/*.{ts,tsx,js,jsx}';
+@source '../../../../libs/ui/**/*.{ts,tsx,js,jsx}';
 
 @layer base {
     :root {
@@ -30,6 +33,15 @@
         --destructive-foreground: 210 40% 98%;
 
         --ring: 215 20.2% 65.1%;
+
+        --sidebar: 0 0% 98%;
+        --sidebar-foreground: 240 5.3% 26.1%;
+        --sidebar-primary: 240 5.9% 10%;
+        --sidebar-primary-foreground: 0 0% 98%;
+        --sidebar-accent: 240 4.8% 95.9%;
+        --sidebar-accent-foreground: 240 5.9% 10%;
+        --sidebar-border: 220 13% 91%;
+        --sidebar-ring: 217.2 91.2% 59.8%;
 
         --radius: 0.5rem;
     }
@@ -63,6 +75,15 @@
         --destructive-foreground: 210 40% 98%;
 
         --ring: 216 34% 17%;
+
+        --sidebar: 240 5.9% 10%;
+        --sidebar-foreground: 240 4.8% 95.9%;
+        --sidebar-primary: 224.3 76.3% 48%;
+        --sidebar-primary-foreground: 0 0% 100%;
+        --sidebar-accent: 240 3.7% 15.9%;
+        --sidebar-accent-foreground: 240 4.8% 95.9%;
+        --sidebar-border: 240 3.7% 15.9%;
+        --sidebar-ring: 217.2 91.2% 59.8%;
 
         --radius: 0.5rem;
     }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,3 @@
-import "./global.css"
 import MusicApp from './_components/music-app';
 
 export default function Index() {

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -2,94 +2,104 @@ import { join } from 'path';
 import { createGlobPatternsForDependencies } from '@nx/react/tailwind';
 import type { Config } from 'tailwindcss';
 import TailwindAnimation from 'tailwindcss-animate';
-import { nextui } from '@nextui-org/react';
 
 const config = {
-  darkMode: ['class', '.dark'],
-  content: [
-    join(
-      __dirname,
-      '{src,pages,components,app}/**/*!(*.stories|*.spec).{ts,tsx,html}'
-    ),
-    '../../node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}',
-    ...createGlobPatternsForDependencies(__dirname),
-  ],
-  prefix: '',
-  theme: {
-    container: {
-      center: true,
-      padding: '2rem',
-      screens: {
-        '2xl': '1400px',
-      },
+    darkMode: ['class', '.dark'],
+    content: [
+        join(
+            __dirname,
+            '{src,pages,components,app}/**/*!(*.stories|*.spec).{ts,tsx,html}',
+        ),
+        ...createGlobPatternsForDependencies(__dirname),
+    ],
+    prefix: '',
+    theme: {
+        container: {
+            center: true,
+            padding: '2rem',
+            screens: {
+                '2xl': '1400px',
+            },
+        },
+        extend: {
+            fontFamily: {
+                header: ['var(--font-header)'],
+                subtitle: ['var(--font-subtitle)'],
+                title: ['var(--font-title)'],
+                light: ['var(--font-light)'],
+                text: ['var(--font-text)'],
+                'text-mono': ['var(--font-text-mono)'],
+                'code-mono': ['var(--font-code-mono)'],
+            },
+            colors: {
+                border: 'hsl(var(--border))',
+                input: 'hsl(var(--input))',
+                ring: 'hsl(var(--ring))',
+                background: 'hsl(var(--background))',
+                foreground: 'hsl(var(--foreground))',
+                primary: {
+                    DEFAULT: 'hsl(var(--primary))',
+                    foreground: 'hsl(var(--primary-foreground))',
+                },
+                secondary: {
+                    DEFAULT: 'hsl(var(--secondary))',
+                    foreground: 'hsl(var(--secondary-foreground))',
+                },
+                destructive: {
+                    DEFAULT: 'hsl(var(--destructive))',
+                    foreground: 'hsl(var(--destructive-foreground))',
+                },
+                muted: {
+                    DEFAULT: 'hsl(var(--muted))',
+                    foreground: 'hsl(var(--muted-foreground))',
+                },
+                accent: {
+                    DEFAULT: 'hsl(var(--accent))',
+                    foreground: 'hsl(var(--accent-foreground))',
+                },
+                popover: {
+                    DEFAULT: 'hsl(var(--popover))',
+                    foreground: 'hsl(var(--popover-foreground))',
+                },
+                card: {
+                    DEFAULT: 'hsl(var(--card))',
+                    foreground: 'hsl(var(--card-foreground))',
+                },
+                sidebar: {
+                    DEFAULT: 'hsl(var(--sidebar))',
+                    foreground: 'hsl(var(--sidebar-foreground))',
+                    primary: 'hsl(var(--sidebar-primary))',
+                    'primary-foreground':
+                        'hsl(var(--sidebar-primary-foreground))',
+                    accent: 'hsl(var(--sidebar-accent))',
+                    'accent-foreground':
+                        'hsl(var(--sidebar-accent-foreground))',
+                    border: 'hsl(var(--sidebar-border))',
+                    ring: 'hsl(var(--sidebar-ring))',
+                },
+            },
+            borderRadius: {
+                lg: 'var(--radius)',
+                md: 'calc(var(--radius) - 2px)',
+                sm: 'calc(var(--radius) - 4px)',
+            },
+            keyframes: {
+                'accordion-down': {
+                    from: { height: '0' },
+                    to: { height: 'var(--radix-accordion-content-height)' },
+                },
+                'accordion-up': {
+                    from: { height: 'var(--radix-accordion-content-height)' },
+                    to: { height: '0' },
+                },
+            },
+            animation: {
+                'accordion-down': 'accordion-down 0.2s ease-out',
+                'accordion-up': 'accordion-up 0.2s ease-out',
+            },
+        },
     },
-    extend: {
-      fontFamily: {
-        header: ['var(--font-header)'],
-        subtitle: ['var(--font-subtitle)'],
-        title: ['var(--font-title)'],
-        light: ['var(--font-light)'],
-        text: ['var(--font-text)'],
-        'text-mono': ['var(--font-text-mono)'],
-        'code-mono': ['var(--font-code-mono)'],
-      },
-      colors: {
-        border: 'hsl(var(--border))',
-        input: 'hsl(var(--input))',
-        ring: 'hsl(var(--ring))',
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
-        primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))',
-        },
-        secondary: {
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))',
-        },
-        destructive: {
-          DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))',
-        },
-        muted: {
-          DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))',
-        },
-        accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
-        },
-        popover: {
-          DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))',
-        },
-        card: {
-          DEFAULT: 'hsl(var(--card))',
-          foreground: 'hsl(var(--card-foreground))',
-        },
-      },
-      borderRadius: {
-        lg: 'var(--radius)',
-        md: 'calc(var(--radius) - 2px)',
-        sm: 'calc(var(--radius) - 4px)',
-      },
-      keyframes: {
-        'accordion-down': {
-          from: { height: '0' },
-          to: { height: 'var(--radix-accordion-content-height)' },
-        },
-        'accordion-up': {
-          from: { height: 'var(--radix-accordion-content-height)' },
-          to: { height: '0' },
-        },
-      },
-      animation: {
-        'accordion-down': 'accordion-down 0.2s ease-out',
-        'accordion-up': 'accordion-up 0.2s ease-out',
-      },
-    },
-  },
-  plugins: [nextui(), TailwindAnimation],
+    plugins: [TailwindAnimation],
 } satisfies Config;
 
 export default config;


### PR DESCRIPTION
## Summary
- implement dashboard shell interaction baseline so navigation and playback controls feel usable before core music features.
- fix Tailwind/sidebar token integration so mobile sidebar renders with the correct background and theme colors.

## What was done
- **Sidebar and navigation UX**
  - added active-route highlighting for sidebar links.
  - improved playlist dialog behavior (Enter to submit, explicit Cancel action).
  - added inline creation feedback text for playlists.
  - added placeholder catch-all route for in-progress dashboard sections to avoid dead links/404 breakage.

- **Dashboard interaction baseline**
  - upgraded dashboard from static mock to stateful shell interactions:
    - play/pause toggle
    - next/previous track controls
    - shuffle action
    - selecting tracks from trending rows, mixes, and release cards
    - progress/time updates for now-playing state
    - mute/unmute state

- **Search and keyboard behavior**
  - added track filtering by query.
  - added clear-search control.
  - added `/` shortcut to focus search and `Esc` to clear.

- **Resilience and polish**
  - added loading skeleton state for trending section.
  - added empty-state messaging when search has no matches.

- **Tailwind + sidebar styling fixes**
  - aligned Tailwind color tokens for sidebar variables in `tailwind.config.ts`.
  - updated `global.css` theme variables (including sidebar tokens) to ensure mobile sheet/sidebar background renders correctly.
